### PR TITLE
Added resources/sass/tool.scss to webpack.mix.js to avoid file not found errors for the nova tool css file

### DIFF
--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -1,3 +1,4 @@
-let mix = require('laravel-mix')
+let mix = require('laravel-mix');
 
 mix.js('resources/js/tool.js', 'dist/js');
+mix.sass('resources/sass/tool.scss', 'dist/css');


### PR DESCRIPTION
The route `/nova-api/styles/nova-mailman` gives the following error:

```
file_get_contents(/vendor/jstoone/nova-mailman/src/../dist/css/tool.css): failed to open stream: No such file or directory
```

I tried removing the (empty) tool scss file from the project, but Nova requires it to be there:
```
/vendor/laravel/nova/src/Http/Controllers/StyleController.php
Undefined index: nova-mailman
```

So I added the tools.scss file to mix which creates the file in the `dist/css` folder.

